### PR TITLE
encode: add SetExplicitDocumentStart option

### DIFF
--- a/apic.go
+++ b/apic.go
@@ -1,17 +1,17 @@
-// 
+//
 // Copyright (c) 2011-2019 Canonical Ltd
 // Copyright (c) 2006-2010 Kirill Simonov
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
 // the Software without restriction, including without limitation the rights to
 // use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
 // of the Software, and to permit persons to whom the Software is furnished to do
 // so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -185,6 +185,11 @@ func yaml_emitter_set_unicode(emitter *yaml_emitter_t, unicode bool) {
 // Set the preferred line break character.
 func yaml_emitter_set_break(emitter *yaml_emitter_t, line_break yaml_break_t) {
 	emitter.line_break = line_break
+}
+
+// Set explicit document start.
+func yaml_emitter_set_explicit_document_start(emitter *yaml_emitter_t, document_start bool) {
+	emitter.explicit_document_start = document_start
 }
 
 ///*

--- a/emitterc.go
+++ b/emitterc.go
@@ -162,10 +162,9 @@ func yaml_emitter_emit(emitter *yaml_emitter_t, event *yaml_event_t) bool {
 // Check if we need to accumulate more events before emitting.
 //
 // We accumulate extra
-//  - 1 event for DOCUMENT-START
-//  - 2 events for SEQUENCE-START
-//  - 3 events for MAPPING-START
-//
+//   - 1 event for DOCUMENT-START
+//   - 2 events for SEQUENCE-START
+//   - 3 events for MAPPING-START
 func yaml_emitter_need_more_events(emitter *yaml_emitter_t) bool {
 	if emitter.events_head == len(emitter.events) {
 		return true
@@ -241,7 +240,7 @@ func yaml_emitter_increase_indent(emitter *yaml_emitter_t, flow, indentless bool
 			emitter.indent += 2
 		} else {
 			// Everything else aligns to the chosen indentation.
-			emitter.indent = emitter.best_indent*((emitter.indent+emitter.best_indent)/emitter.best_indent)
+			emitter.indent = emitter.best_indent * ((emitter.indent + emitter.best_indent) / emitter.best_indent)
 		}
 	}
 	return true
@@ -384,7 +383,7 @@ func yaml_emitter_emit_document_start(emitter *yaml_emitter_t, event *yaml_event
 		}
 
 		implicit := event.implicit
-		if !first || emitter.canonical {
+		if emitter.explicit_document_start || !first || emitter.canonical {
 			implicit = false
 		}
 

--- a/encode_test.go
+++ b/encode_test.go
@@ -17,7 +17,9 @@ package yaml_test
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
+	"io"
 	"math"
 	"strconv"
 	"strings"
@@ -745,6 +747,21 @@ func (s *S) TestSortedOutput(c *C) {
 		}
 		last = index
 	}
+}
+
+func (s *S) TestExplicitDocumentStart(c *C) {
+	reader := bytes.NewReader([]byte{})
+	decoder := yaml.NewDecoder(reader)
+	var n yaml.Node
+	err := decoder.Decode(&n)
+	c.Assert(errors.Is(err, io.EOF), Equals, true)
+
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetExplicitDocumentStart()
+	err = enc.Encode(n)
+	c.Assert(err, IsNil)
+	c.Assert(strings.Contains(buf.String(), "---"), Equals, true)
 }
 
 func newTime(t time.Time) *time.Time {

--- a/yaml.go
+++ b/yaml.go
@@ -297,6 +297,12 @@ func (e *Encoder) SetLineBreakStyle(style LineBreakStyle) {
 	}
 }
 
+// SetExplicitDocumentStart forces the document start token
+// (---) to always be written.
+func (e *Encoder) SetExplicitDocumentStart() {
+	yaml_emitter_set_explicit_document_start(&e.encoder.emitter, true)
+}
+
 // Close closes the encoder by writing any remaining data.
 // It does not write a stream terminating string "...".
 func (e *Encoder) Close() (err error) {

--- a/yamlh.go
+++ b/yamlh.go
@@ -438,7 +438,9 @@ type yaml_document_t struct {
 // The number of written bytes should be set to the size_read variable.
 //
 // [in,out]   data        A pointer to an application data specified by
-//                        yaml_parser_set_input().
+//
+//	yaml_parser_set_input().
+//
 // [out]      buffer      The buffer to write the data from the source.
 // [in]       size        The size of the buffer.
 // [out]      size_read   The actual number of bytes read from the source.
@@ -639,7 +641,6 @@ type yaml_parser_t struct {
 }
 
 type yaml_comment_t struct {
-
 	scan_mark  yaml_mark_t // Position where scanning for comments started
 	token_mark yaml_mark_t // Position after which tokens will be associated with this comment
 	start_mark yaml_mark_t // Position of '#' comment mark
@@ -659,13 +660,14 @@ type yaml_comment_t struct {
 // @a buffer to the output.
 //
 // @param[in,out]   data        A pointer to an application data specified by
-//                              yaml_emitter_set_output().
+//
+//	yaml_emitter_set_output().
+//
 // @param[in]       buffer      The buffer with bytes to be written.
 // @param[in]       size        The size of the buffer.
 //
 // @returns On success, the handler should return @c 1.  If the handler failed,
 // the returned value should be @c 0.
-//
 type yaml_write_handler_t func(emitter *yaml_emitter_t, buffer []byte) error
 
 type yaml_emitter_state_t int
@@ -724,11 +726,12 @@ type yaml_emitter_t struct {
 
 	// Emitter stuff
 
-	canonical   bool         // If the output is in the canonical style?
-	best_indent int          // The number of indentation spaces.
-	best_width  int          // The preferred width of the output lines.
-	unicode     bool         // Allow unescaped non-ASCII characters?
-	line_break  yaml_break_t // The preferred line break.
+	canonical               bool         // If the output is in the canonical style?
+	best_indent             int          // The number of indentation spaces.
+	best_width              int          // The preferred width of the output lines.
+	unicode                 bool         // Allow unescaped non-ASCII characters?
+	line_break              yaml_break_t // The preferred line break.
+	explicit_document_start bool         // Force an explicit document start
 
 	state  yaml_emitter_state_t   // The current emitter state.
 	states []yaml_emitter_state_t // The stack of states.


### PR DESCRIPTION
Adds an option to the emitter to always have an explicit document start. This option can be used as an override to the default behaviour, which checks that it's not the first document start or that it's canonical style before setting something as explicit. This allows for the opening document start to always be written (even when it wasn't originally specified).