### PR TITLE
add override for scanning folded as literal

### DIFF
--- a/apic.go
+++ b/apic.go
@@ -74,6 +74,10 @@ func yaml_reader_read_handler(parser *yaml_parser_t, buffer []byte) (n int, err 
 	return parser.input_reader.Read(buffer)
 }
 
+func yaml_parser_set_scan_folded_as_literal(parser *yaml_parser_t, scan_literal bool) {
+	parser.scan_folded_as_literal = scan_literal
+}
+
 // Set a string input.
 func yaml_parser_set_input_string(parser *yaml_parser_t, input []byte) {
 	if parser.read_handler != nil {
@@ -190,6 +194,10 @@ func yaml_emitter_set_break(emitter *yaml_emitter_t, line_break yaml_break_t) {
 // Set explicit document start.
 func yaml_emitter_set_explicit_document_start(emitter *yaml_emitter_t, document_start bool) {
 	emitter.explicit_document_start = document_start
+}
+
+func yaml_emitter_set_assume_folded_as_literal(emitter *yaml_emitter_t, folded_as_literal bool) {
+	emitter.assume_folded_as_literal = folded_as_literal
 }
 
 ///*

--- a/emitterc.go
+++ b/emitterc.go
@@ -1946,7 +1946,7 @@ func yaml_emitter_write_folded_scalar(emitter *yaml_emitter_t, value []byte) boo
 				for is_break(value, k) {
 					k += width(value[k])
 				}
-				if !is_blankz(value, k) {
+				if !emitter.assume_folded_as_literal && !is_blankz(value, k) {
 					if !put_break(emitter) {
 						return false
 					}

--- a/scannerc.go
+++ b/scannerc.go
@@ -2190,6 +2190,9 @@ func yaml_parser_scan_uri_escapes(parser *yaml_parser_t, directive bool, start_m
 
 // Scan a block scalar.
 func yaml_parser_scan_block_scalar(parser *yaml_parser_t, token *yaml_token_t, literal bool) bool {
+	// Scan as literal override
+	scan_as_literal := parser.scan_folded_as_literal || literal
+
 	// Eat the indicator '|' or '>'.
 	start_mark := parser.mark
 	skip(parser)
@@ -2318,7 +2321,7 @@ func yaml_parser_scan_block_scalar(parser *yaml_parser_t, token *yaml_token_t, l
 		trailing_blank = is_blank(parser.buffer, parser.buffer_pos)
 
 		// Check if we need to fold the leading line break.
-		if !literal && !leading_blank && !trailing_blank && len(leading_break) > 0 && leading_break[0] == '\n' {
+		if !scan_as_literal && !leading_blank && !trailing_blank && len(leading_break) > 0 && leading_break[0] == '\n' {
 			// Do we need to join the lines by space?
 			if len(trailing_breaks) == 0 {
 				s = append(s, ' ')

--- a/yaml.go
+++ b/yaml.go
@@ -109,6 +109,10 @@ func (dec *Decoder) KnownFields(enable bool) {
 	dec.knownFields = enable
 }
 
+func (dec *Decoder) SetScanBlockScalarAsLiteral(scanLiteral bool) {
+	yaml_parser_set_scan_folded_as_literal(&dec.parser.parser, scanLiteral)
+}
+
 // Decode reads the next YAML-encoded value from its input
 // and stores it in the value pointed to by v.
 //
@@ -301,6 +305,10 @@ func (e *Encoder) SetLineBreakStyle(style LineBreakStyle) {
 // (---) to always be written.
 func (e *Encoder) SetExplicitDocumentStart() {
 	yaml_emitter_set_explicit_document_start(&e.encoder.emitter, true)
+}
+
+func (e *Encoder) SetAssumeBlockAsLiteral(assumeLiteralBlock bool) {
+	yaml_emitter_set_assume_folded_as_literal(&e.encoder.emitter, assumeLiteralBlock)
 }
 
 // Close closes the encoder by writing any remaining data.

--- a/yamlh.go
+++ b/yamlh.go
@@ -556,6 +556,10 @@ type yaml_alias_data_t struct {
 // yaml_parser_ family of functions.
 type yaml_parser_t struct {
 
+	// Option
+
+	scan_folded_as_literal bool
+
 	// Error handling
 
 	error yaml_error_type_t // Error type.
@@ -726,12 +730,13 @@ type yaml_emitter_t struct {
 
 	// Emitter stuff
 
-	canonical               bool         // If the output is in the canonical style?
-	best_indent             int          // The number of indentation spaces.
-	best_width              int          // The preferred width of the output lines.
-	unicode                 bool         // Allow unescaped non-ASCII characters?
-	line_break              yaml_break_t // The preferred line break.
-	explicit_document_start bool         // Force an explicit document start
+	canonical                bool         // If the output is in the canonical style?
+	best_indent              int          // The number of indentation spaces.
+	best_width               int          // The preferred width of the output lines.
+	unicode                  bool         // Allow unescaped non-ASCII characters?
+	line_break               yaml_break_t // The preferred line break.
+	explicit_document_start  bool         // Force an explicit document start
+	assume_folded_as_literal bool         // Assume blocks were scanned as literals
 
 	state  yaml_emitter_state_t   // The current emitter state.
 	states []yaml_emitter_state_t // The stack of states.


### PR DESCRIPTION
To allow yamlfmt to preserve the original state of folded blocks upon decode and re-encode, this PR adds an override that will allow folded block scalars to be scanned as literal and allow the emitter to assume that a block scalar was scanned as a literal.