### PR TITLE
emitter: add pad_line_comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,17 @@ FORK
 This is specifically a fork maintained by @braydonk particularly for
 the interests of [yamlfmt](https://www.github.com/google/yamlfmt).
 
+The focus of the fixes to this repo are specifically on the workflow of
+Unmarshalling to `yaml.Node` and immediately encoding. Many of the fixes
+will likely work for any workflow through the library and can potentially
+be adopted, but there may be cases where it won't.
+This repo also adds tests to `formattest` which are test cases focused on
+this workflow.
+
 The following is the documentation as stated upstream. I will change it
 when necessary.
+
+-------------------------------------------------------------------------
 
 Introduction
 ------------

--- a/apic.go
+++ b/apic.go
@@ -206,6 +206,11 @@ func yaml_emitter_set_indentless_block_sequence(emitter *yaml_emitter_t, indentl
 	emitter.indentless_block_sequence = indentless_block_sequence
 }
 
+// Set pad line comment
+func yaml_emitter_set_pad_line_comment(emitter *yaml_emitter_t, pad_line_comment int) {
+	emitter.pad_line_comment = pad_line_comment
+}
+
 ///*
 // * Destroy a token object.
 // */

--- a/emitterc.go
+++ b/emitterc.go
@@ -1118,7 +1118,7 @@ func yaml_emitter_process_head_comment(emitter *yaml_emitter_t) bool {
 		if !yaml_emitter_write_indent(emitter) {
 			return false
 		}
-		if !yaml_emitter_write_comment(emitter, emitter.tail_comment) {
+		if !yaml_emitter_write_comment(emitter, emitter.tail_comment, 0) {
 			return false
 		}
 		emitter.tail_comment = emitter.tail_comment[:0]
@@ -1134,7 +1134,7 @@ func yaml_emitter_process_head_comment(emitter *yaml_emitter_t) bool {
 	if !yaml_emitter_write_indent(emitter) {
 		return false
 	}
-	if !yaml_emitter_write_comment(emitter, emitter.head_comment) {
+	if !yaml_emitter_write_comment(emitter, emitter.head_comment, 0) {
 		return false
 	}
 	emitter.head_comment = emitter.head_comment[:0]
@@ -1151,7 +1151,7 @@ func yaml_emitter_process_line_comment(emitter *yaml_emitter_t) bool {
 			return false
 		}
 	}
-	if !yaml_emitter_write_comment(emitter, emitter.line_comment) {
+	if !yaml_emitter_write_comment(emitter, emitter.line_comment, emitter.pad_line_comment) {
 		return false
 	}
 	emitter.line_comment = emitter.line_comment[:0]
@@ -1166,7 +1166,7 @@ func yaml_emitter_process_foot_comment(emitter *yaml_emitter_t) bool {
 	if !yaml_emitter_write_indent(emitter) {
 		return false
 	}
-	if !yaml_emitter_write_comment(emitter, emitter.foot_comment) {
+	if !yaml_emitter_write_comment(emitter, emitter.foot_comment, 0) {
 		return false
 	}
 	emitter.foot_comment = emitter.foot_comment[:0]
@@ -1980,12 +1980,12 @@ func yaml_emitter_write_folded_scalar(emitter *yaml_emitter_t, value []byte) boo
 	return true
 }
 
-func yaml_emitter_write_comment(emitter *yaml_emitter_t, comment []byte) bool {
+func yaml_emitter_write_comment(emitter *yaml_emitter_t, comment []byte, padding int) bool {
 	breaks := false
 	pound := false
 
 	// [Go] Start by adding any additional padding to the line comment.
-	for i := 0; i < emitter.pad_line_comment; i++ {
+	for i := 0; i < padding; i++ {
 		if !put(emitter, ' ') {
 			return false
 		}

--- a/emitterc.go
+++ b/emitterc.go
@@ -1983,6 +1983,14 @@ func yaml_emitter_write_folded_scalar(emitter *yaml_emitter_t, value []byte) boo
 func yaml_emitter_write_comment(emitter *yaml_emitter_t, comment []byte) bool {
 	breaks := false
 	pound := false
+
+	// [Go] Start by adding any additional padding to the line comment.
+	for i := 0; i < emitter.pad_line_comment; i++ {
+		if !put(emitter, ' ') {
+			return false
+		}
+	}
+
 	for i := 0; i < len(comment); {
 		if is_break(comment, i) {
 			if !write_break(emitter, comment, &i) {

--- a/formattest/encode_test.go
+++ b/formattest/encode_test.go
@@ -62,3 +62,14 @@ func TestDropMergeTag(t *testing.T) {
 		},
 	}.Run(t)
 }
+
+func TestPadLineComment(t *testing.T) {
+	formatTestCase{
+		name:             "pad line comment",
+		folder:           "pad_line_comment",
+		configureDecoder: noopDecoder,
+		configureEncoder: func(enc *yaml.Encoder) {
+			enc.SetPadLineComment(1)
+		},
+	}.Run(t)
+}

--- a/formattest/testdata/pad_line_comment/expected.yaml
+++ b/formattest/testdata/pad_line_comment/expected.yaml
@@ -1,0 +1,1 @@
+a: 1  # comment

--- a/formattest/testdata/pad_line_comment/expected.yaml
+++ b/formattest/testdata/pad_line_comment/expected.yaml
@@ -1,1 +1,2 @@
+# comment
 a: 1  # comment

--- a/formattest/testdata/pad_line_comment/input.yaml
+++ b/formattest/testdata/pad_line_comment/input.yaml
@@ -1,1 +1,2 @@
+# comment
 a: 1 # comment

--- a/formattest/testdata/pad_line_comment/input.yaml
+++ b/formattest/testdata/pad_line_comment/input.yaml
@@ -1,0 +1,1 @@
+a: 1 # comment

--- a/yaml.go
+++ b/yaml.go
@@ -323,6 +323,11 @@ func (e *Encoder) SetDropMergeTag(dropMergeTag bool) {
 	e.encoder.optDropMergeTag = dropMergeTag
 }
 
+// SetPadLineComment sets the option to add padding to a LineComment spacing.
+func (e *Encoder) SetPadLineComment(padding int) {
+	yaml_emitter_set_pad_line_comment(&e.encoder.emitter, padding)
+}
+
 // Close closes the encoder by writing any remaining data.
 // It does not write a stream terminating string "...".
 func (e *Encoder) Close() (err error) {

--- a/yamlh.go
+++ b/yamlh.go
@@ -738,6 +738,7 @@ type yaml_emitter_t struct {
 	explicit_document_start   bool         // Force an explicit document start
 	assume_folded_as_literal  bool         // Assume blocks were scanned as literals
 	indentless_block_sequence bool         // Do not indent block sequences
+	pad_line_comment          int          // Pad line comment by requested amount
 
 	state  yaml_emitter_state_t   // The current emitter state.
 	states []yaml_emitter_state_t // The stack of states.


### PR DESCRIPTION
Added an option to pad line comment by the additional single space in formatted output.

Part of the work for https://github.com/google/yamlfmt/issues/104