### PR TITLE
Add a configuration option to indent a root-level array the same as a nested one

### DIFF
--- a/emitterc.go
+++ b/emitterc.go
@@ -228,7 +228,9 @@ func yaml_emitter_append_tag_directive(emitter *yaml_emitter_t, value *yaml_tag_
 func yaml_emitter_increase_indent(emitter *yaml_emitter_t, flow, indentless bool) bool {
 	emitter.indents = append(emitter.indents, emitter.indent)
 	if emitter.indent < 0 {
-		if flow {
+		if emitter.indent_root_array && emitter.state == yaml_EMIT_BLOCK_SEQUENCE_FIRST_ITEM_STATE {
+			emitter.indent = emitter.best_array_indent
+		} else if flow {
 			emitter.indent = emitter.best_indent
 		} else {
 			emitter.indent = 0

--- a/encode.go
+++ b/encode.go
@@ -29,14 +29,15 @@ import (
 )
 
 type encoder struct {
-	emitter         yaml_emitter_t
-	event           yaml_event_t
-	out             []byte
-	flow            bool
-	indent          int
-	array_indent    int
-	doneInit        bool
-	optDropMergeTag bool
+	emitter           yaml_emitter_t
+	event             yaml_event_t
+	out               []byte
+	flow              bool
+	indent            int
+	array_indent      int
+	indent_root_array bool
+	doneInit          bool
+	optDropMergeTag   bool
 }
 
 func newEncoder() *encoder {
@@ -69,6 +70,7 @@ func (e *encoder) init() {
 	}
 	e.emitter.best_indent = e.indent
 	e.emitter.best_array_indent = e.array_indent
+	e.emitter.indent_root_array = e.indent_root_array
 	yaml_stream_start_event_initialize(&e.event, yaml_UTF8_ENCODING)
 	e.emit()
 	e.doneInit = true

--- a/formattest/encode_test.go
+++ b/formattest/encode_test.go
@@ -85,3 +85,15 @@ func TestAltArrayIndent(t *testing.T) {
 		},
 	}.Run(t)
 }
+
+func TestAltArrayIndentRoot(t *testing.T) {
+	formatTestCase{
+		name:             "alternate array indent (root)",
+		folder:           "alt_array_indent_root",
+		configureDecoder: noopDecoder,
+		configureEncoder: func(enc *yaml.Encoder) {
+			enc.SetIndent(4)
+			enc.SetArrayIndent(1)
+		},
+	}.Run(t)
+}

--- a/formattest/encode_test.go
+++ b/formattest/encode_test.go
@@ -93,7 +93,8 @@ func TestAltArrayIndentRoot(t *testing.T) {
 		configureDecoder: noopDecoder,
 		configureEncoder: func(enc *yaml.Encoder) {
 			enc.SetIndent(4)
-			enc.SetArrayIndent(1)
+			enc.SetArrayIndent(2)
+			enc.SetIndentRootArray(true)
 		},
 	}.Run(t)
 }

--- a/formattest/testdata/alt_array_indent/expected.yaml
+++ b/formattest/testdata/alt_array_indent/expected.yaml
@@ -3,3 +3,7 @@ a:
 c:
  - array
  - values
+d:
+    e:
+     - abc
+     - def

--- a/formattest/testdata/alt_array_indent/input.yaml
+++ b/formattest/testdata/alt_array_indent/input.yaml
@@ -1,5 +1,9 @@
 a:
-  b: 1
+   b: 1
 c:
-  - array
-  - values
+   - array
+   - values
+d:
+   e:
+      - abc
+      - def

--- a/formattest/testdata/alt_array_indent_root/expected.yaml
+++ b/formattest/testdata/alt_array_indent_root/expected.yaml
@@ -1,9 +1,8 @@
- - a:
-      b: 1
- - c:
-    - array
-    - values
- - d:
-      e:
-       - abc
-       - def
+  - a:
+        b: 1
+  - c:
+    d:
+  - e:
+        f:
+          - abc
+          - def

--- a/formattest/testdata/alt_array_indent_root/expected.yaml
+++ b/formattest/testdata/alt_array_indent_root/expected.yaml
@@ -1,0 +1,9 @@
+ - a:
+      b: 1
+ - c:
+    - array
+    - values
+ - d:
+      e:
+       - abc
+       - def

--- a/formattest/testdata/alt_array_indent_root/input.yaml
+++ b/formattest/testdata/alt_array_indent_root/input.yaml
@@ -1,0 +1,9 @@
+- a:
+    b: 1
+- c:
+    - array
+    - values
+- d:
+    e:
+      - abc
+      - def

--- a/formattest/testdata/alt_array_indent_root/input.yaml
+++ b/formattest/testdata/alt_array_indent_root/input.yaml
@@ -1,9 +1,8 @@
 - a:
     b: 1
 - c:
-    - array
-    - values
-- d:
-    e:
-      - abc
-      - def
+  d:
+- e:
+    f:
+     - abc
+     - def

--- a/yaml.go
+++ b/yaml.go
@@ -288,6 +288,12 @@ func (e *Encoder) SetArrayIndent(spaces int) {
 	e.encoder.array_indent = spaces
 }
 
+// SetIndentRootArray changes whether arrays at the root of the document
+// should be indented as if they were children.
+func (e *Encoder) SetIndentRootArray(indent_root_array bool) {
+	e.encoder.indent_root_array = indent_root_array
+}
+
 // SetWidth sets the intended line length.
 func (e *Encoder) SetWidth(width int) {
 	yaml_emitter_set_width(&e.encoder.emitter, width)

--- a/yamlh.go
+++ b/yamlh.go
@@ -731,14 +731,15 @@ type yaml_emitter_t struct {
 	// Emitter stuff
 
 	canonical                 bool         // If the output is in the canonical style?
+	best_width                int          // The preferred width of the output lines.
 	best_indent               int          // The number of indentation spaces.
 	best_array_indent         int          // The number of indentation spaces to use for arrays
-	best_width                int          // The preferred width of the output lines.
+	indent_root_array         bool         // Indent a root-level array as if it were a child?
+	indentless_block_sequence bool         // Do not indent block sequences
 	unicode                   bool         // Allow unescaped non-ASCII characters?
 	line_break                yaml_break_t // The preferred line break.
 	explicit_document_start   bool         // Force an explicit document start
 	assume_folded_as_literal  bool         // Assume blocks were scanned as literals
-	indentless_block_sequence bool         // Do not indent block sequences
 	pad_line_comments         int          // The number of spaces to insert before line comments.
 
 	state  yaml_emitter_state_t   // The current emitter state.


### PR DESCRIPTION
(Never made a PR to a PR before, lmao.)

This is intended to be used alongside the new `array_indent` to produce consistent 'outdented'-style indentation for list-items:

With the option disabled, `array_indent` produces internally-consistent, but unaligned blocks:

```yaml
# .yamlfmt.yaml
formatter:
    indent: 4
    array_indent: 2
```

<details><summary>Output:</summary>

```yaml
- name: Ensure non-root user and SSH are configured
  hosts: berit.ell

  # For newly-provisioned hosts, need to wait for sshd to come up
  gather_facts: false
  pre_tasks:
  roles:
    - role: preroll

- name: Setup windmill
  hosts: eurydice.ell.io

  gather_facts: false
  pre_tasks:
    - name: Wait for sshd on remote host to come up
      ansible.builtin.wait_for_connection:
        delay: 5
        timeout: 1800
    - name: Gather facts for the first time
      ansible.builtin.setup:

  roles:
    - role: preroll
    - role: aisbergg.acl
      become: true
    - role: geerlingguy.docker
      become: true
    - role: dokku_bot.ansible_dokku
      become: true
    - windmill
```

</details>

Note that despite `indent: 4`, most of the content is now aligned to either the 2nd or 6th column. Most text-editors are going to behave poorly when you hit the tab key or indent/undent blocks, with this layout.

With this new config enabled, `indent_root_array: true`, all of the textual content of the file stays aligned to the 4-space grid:

```yaml
# .yamlfmt.yaml
formatter:
    indent: 4
    array_indent: 2
    indent_root_array: true
```

<details><summary>Output:</summary>

```yaml
  - name: Ensure non-root user and SSH are configured
    hosts: berit.ell

    # For newly-provisioned hosts, need to wait for sshd to come up
    gather_facts: false
    pre_tasks:
    roles:
      - role: preroll

  - name: Setup windmill
    hosts: eurydice.ell.io

    gather_facts: false
    pre_tasks:
      - name: Wait for sshd on remote host to come up
        ansible.builtin.wait_for_connection:
            delay: 5
            timeout: 1800
      - name: Gather facts for the first time
        ansible.builtin.setup:

    roles:
      - role: preroll
      - role: aisbergg.acl
        become: true
      - role: geerlingguy.docker
        become: true
      - role: dokku_bot.ansible_dokku
        become: true
      - windmill
```

</details>