### PR TITLE
fix document start comment handling

### DIFF
--- a/emitterc.go
+++ b/emitterc.go
@@ -442,6 +442,16 @@ func yaml_emitter_emit_document_start(emitter *yaml_emitter_t, event *yaml_event
 		if yaml_emitter_check_empty_document(emitter) {
 			implicit = false
 		}
+
+		// braydonk: This puts head comments above the document
+		// start token, rather than the previous behaviour which
+		// put them after the document start for some reason.
+		if len(emitter.head_comment) > 0 {
+			if !yaml_emitter_process_head_comment(emitter) {
+				return false
+			}
+		}
+
 		if !implicit {
 			if !yaml_emitter_write_indent(emitter) {
 				return false
@@ -456,14 +466,20 @@ func yaml_emitter_emit_document_start(emitter *yaml_emitter_t, event *yaml_event
 			}
 		}
 
-		if len(emitter.head_comment) > 0 {
-			if !yaml_emitter_process_head_comment(emitter) {
-				return false
+		// braydonk: Yes I know leaving commented out code in source control
+		// is cringe but if I am in a scenario where my fix breaks something
+		// unexpectedly and I gotta hotfix it back I need to make it easy to
+		// remember what the original setup was.
+		/*
+			if len(emitter.head_comment) > 0 {
+				if !yaml_emitter_process_head_comment(emitter) {
+					return false
+				}
+				if !put_break(emitter) {
+					return false
+				}
 			}
-			if !put_break(emitter) {
-				return false
-			}
-		}
+		*/
 
 		emitter.state = yaml_EMIT_DOCUMENT_CONTENT_STATE
 		return true

--- a/formattest/encode_test.go
+++ b/formattest/encode_test.go
@@ -98,3 +98,25 @@ func TestAltArrayIndentRoot(t *testing.T) {
 		},
 	}.Run(t)
 }
+
+func TestFrontMatter(t *testing.T) {
+	formatTestCase{
+		name:             "frontmatter",
+		folder:           "frontmatter_comments",
+		configureDecoder: noopDecoder,
+		configureEncoder: func(enc *yaml.Encoder) {
+			enc.SetExplicitDocumentStart(true)
+		},
+	}.Run(t)
+}
+
+func TestImplicitDocumentStartComments(t *testing.T) {
+	formatTestCase{
+		name:             "comment implicit document start",
+		folder:           "comment_implicit_document_start",
+		configureDecoder: noopDecoder,
+		configureEncoder: func(enc *yaml.Encoder) {
+			enc.SetExplicitDocumentStart(false)
+		},
+	}.Run(t)
+}

--- a/formattest/testdata/comment_implicit_document_start/expected.yaml
+++ b/formattest/testdata/comment_implicit_document_start/expected.yaml
@@ -1,0 +1,3 @@
+# hi
+# comments
+a: 1

--- a/formattest/testdata/comment_implicit_document_start/input.yaml
+++ b/formattest/testdata/comment_implicit_document_start/input.yaml
@@ -1,0 +1,3 @@
+# hi
+# comments
+a: 1

--- a/formattest/testdata/frontmatter_comments/expected.yaml
+++ b/formattest/testdata/frontmatter_comments/expected.yaml
@@ -1,0 +1,4 @@
+# comment
+# another comment
+---
+a: 1

--- a/formattest/testdata/frontmatter_comments/input.yaml
+++ b/formattest/testdata/frontmatter_comments/input.yaml
@@ -1,0 +1,4 @@
+# comment
+# another comment
+---
+a: 1

--- a/parserc.go
+++ b/parserc.go
@@ -337,7 +337,11 @@ func yaml_parser_parse_document_start(parser *yaml_parser_t, event *yaml_event_t
 			version_directive: version_directive,
 			tag_directives:    tag_directives,
 			implicit:          false,
+			
+			// braydonk: Fixing head comments for explicit document start
+			head_comment: parser.head_comment,
 		}
+		parser.head_comment = []byte{}
 		skip_token(parser)
 
 	} else {


### PR DESCRIPTION
It seems that the upstream library added a particular way of handling head comments on explicit document start. I don't understand why they did this the way they did, it does not seem like it would be the way any user would want it to work.

I was debating whether this should be an opt-in behaviour, but the existing behaviour is so strange that I'm willing to bet that the corrected way is the way any reasonable person would expect it to work.