### PR TITLE
fix superfluous comma in flow mappings

### DIFF
--- a/emitterc.go
+++ b/emitterc.go
@@ -650,7 +650,7 @@ func yaml_emitter_emit_flow_mapping_key(emitter *yaml_emitter_t, event *yaml_eve
 	}
 
 	if event.typ == yaml_MAPPING_END_EVENT {
-		if (emitter.canonical || len(emitter.head_comment)+len(emitter.foot_comment)+len(emitter.tail_comment) > 0) && !first && !trail {
+		if emitter.canonical && !first && !trail {
 			if !yaml_emitter_write_indicator(emitter, []byte{','}, false, false, false) {
 				return false
 			}


### PR DESCRIPTION
When a flow mapping ends in non-canonical mode, the emitter no longer writes a trailing comma before the closing `}` merely because comments are pending.

The comma was a leftover from upstream (117fdf0) and is unnecessary: pending foot comments are emitted after `}`, and head/tail comments always start on a new line. This makes flow mappings consistent with flow sequences, which already only emit the trailing comma in canonical mode.

Also fixes google/yamlfmt#110 and google/yamlfmt#195.